### PR TITLE
fix static static collision crash

### DIFF
--- a/src/Test/Scene/tMultiPhysicsRuntimeShadow.ts
+++ b/src/Test/Scene/tMultiPhysicsRuntimeShadow.ts
@@ -65,7 +65,7 @@ export class SceneBuilder implements ISceneBuilder {
         shadowGenerator.bias = 0.004;
         shadowGenerator.filteringQuality = ShadowGenerator.QUALITY_MEDIUM;
 
-        const wasmInstance = await getBulletWasmInstance(new BulletWasmInstanceTypeMD(), 4);
+        const wasmInstance = await getBulletWasmInstance(new BulletWasmInstanceTypeMD(), 32);
         const runtime = new MultiPhysicsRuntime(wasmInstance, {
             allowDynamicShadow: true,
             preserveBackBuffer: true
@@ -97,8 +97,8 @@ export class SceneBuilder implements ISceneBuilder {
         shadowGenerator.addShadowCaster(baseBox);
         baseBox.receiveShadows = true;
 
-        const rowCount = 2;
-        const columnCount = 2;
+        const rowCount = 4;
+        const columnCount = 8;
         const margin = 20;
 
         const rigidbodyMatrixBuffer = new Float32Array(rbCount * 16 * rowCount * columnCount);

--- a/src/wasm_src/bullet_src/bwRigidBody.h
+++ b/src/wasm_src/bullet_src/bwRigidBody.h
@@ -150,7 +150,6 @@ public:
         if (info->m_motionType == static_cast<uint8_t>(bwRigidBodyMotionType::KINEMATIC))
         {
             m_body.setCollisionFlags(m_body.getCollisionFlags() | btCollisionObject::CF_KINEMATIC_OBJECT);
-            m_body.setActivationState(DISABLE_DEACTIVATION);
         }
         else if (info->m_motionType == static_cast<uint8_t>(bwRigidBodyMotionType::STATIC))
         {
@@ -241,10 +240,10 @@ btRigidBody::btRigidBodyConstructionInfo bwRigidBodyShadow::createRigidBodyConst
 {
     btRigidBody* sourceBody = source->getBody();
     btRigidBody::btRigidBodyConstructionInfo info(
-        sourceBody->getMass(),
+        0.0, //sourceBody->getMass(),
         motionState,
         sourceBody->getCollisionShape(),
-        sourceBody->getLocalInertia()
+        btVector3(0.0, 0.0, 0.0)//sourceBody->getLocalInertia()
     );
     // because shadow is always non-dynamic we don't need to copy damping values
     // info.m_linearDamping = sourceBody->getLinearDamping();


### PR DESCRIPTION
In Broadphase Collision, static or kinematic rigidbodies must be filtered out, otherwise they are UBs and can cause unknown memory overflow issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced physics simulation with expanded object matrices and refined shadow configurations leading to more dynamic performance.
  - Improved collision filtering for more realistic and accurate interaction behaviors in simulations.

- **Refactor**
  - Updated object initialization logic for simulated entities, including adjustments for motion handling and dynamics, ensuring a more stable and natural simulation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->